### PR TITLE
A0-935: Add option to connect to testnet and download db

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -3,6 +3,7 @@ import json
 from itertools import chain
 from os import remove
 from subprocess import Popen, call, PIPE
+from datetime import date, timedelta
 
 from fabric import task
 
@@ -144,21 +145,7 @@ def pid_to_auth(pid):
         return f.readlines()[int(pid)][:-1]
 
 
-@task
-def create_dispatch_cmd(conn, pid):
-    ''' Runs the protocol.'''
-
-    auth = pid_to_auth(pid)
-    libp2p_addresses = []
-    with open("addresses", "r") as f:
-        addresses = [addr.strip() for addr in f.readlines()]
-    with open("libp2p_public_keys", "r") as f:
-        keys = [key.strip() for key in f.readlines()]
-    for address, key in zip(addresses, keys):
-        libp2p_addresses.append(
-            f'/ip4/{address}/tcp/30334/p2p/{key}')
-    bootnodes = " ".join(libp2p_addresses[-2:])
-
+def get_node_flags(auth, bootnodes):
     no_val_flags = [
         '--validator',
         '--prometheus-external',
@@ -191,11 +178,60 @@ def create_dispatch_cmd(conn, pid):
     val_flags.update(custom_val_flags)
     val_flags = [f'{key} {val}' for (key, val) in val_flags.items()]
 
-    flags = " ".join(chain(no_val_flags, val_flags, debug_flags))
-    cmd = f'/home/ubuntu/aleph-node {flags} 2> {pid}.log'
+    return " ".join(chain(no_val_flags, val_flags, debug_flags))
 
+
+@task
+def create_dispatch_cmd(conn, pid):
+    ''' Runs the protocol.'''
+
+    libp2p_addresses = []
+    with open("addresses", "r") as f:
+        addresses = [addr.strip() for addr in f.readlines()]
+    with open("libp2p_public_keys", "r") as f:
+        keys = [key.strip() for key in f.readlines()]
+    for address, key in zip(addresses, keys):
+        libp2p_addresses.append(
+            f'/ip4/{address}/tcp/30334/p2p/{key}')
+    bootnodes = " ".join(libp2p_addresses[-2:])
+
+    auth = pid_to_auth(pid)
+    flags = get_node_flags(auth, bootnodes)
+
+    cmd = f'/home/ubuntu/aleph-node {flags} 2> {pid}.log'
     conn.run("echo > /home/ubuntu/cmd.sh")
     conn.run(f"sed -i '$a{cmd}' /home/ubuntu/cmd.sh")
+
+
+@task
+def create_testnet_dispatch_cmd(conn, pid):
+    ''' Runs the protocol for testnet and downloads db.'''
+
+    bootnodes = []
+    with open("bootnodes", "r") as f:
+        bootnodes = [bn.strip() for bn in f.readlines()]
+    bootnodes = " ".join(bootnodes)
+
+    sync_from_genesis = True
+    with open("sync_from_genesis", "r") as f:
+        sync_from_genesis = f.readline().strip()
+
+    auth = pid_to_auth(pid)
+    flags = get_node_flags(auth, bootnodes)
+    cmd_run = f'/home/ubuntu/aleph-node {flags} 2> {pid}.log'
+    conn.run("echo > /home/ubuntu/cmd.sh")
+    if sync_from_genesis == 'True':
+        conn.run(f"sed -i '$a{cmd_run}' /home/ubuntu/cmd.sh")
+    else:
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+        cmd_download = f'echo Started download >> download_db.log; '\
+            f'wget -O db.tar.gz https://db.test.azero.dev/{yesterday}/db_backup_{yesterday}.tar.gz -nv -a download_db.log; '\
+            f'echo Started unpacking db >> download_db.log; '\
+            f'tar xvzf db.tar.gz -C data/{auth}/chains/testnet; '\
+            f'echo Unpacking done, removing tar.gz >> download_db.log; '\
+            'rm db.tar.gz; '
+        conn.run(f"sed -i '$a{cmd_download}{cmd_run}' /home/ubuntu/cmd.sh")
 
 
 @task

--- a/shell.py
+++ b/shell.py
@@ -514,7 +514,7 @@ def setup_infrastructure(n_parties, chain='dev', regions=use_regions(), instance
         bootstrap_nodes(parties[n_validators:], chain, **chain_flags)
     else:
         color_print('Downloading testnet chainspec')
-        cmd = f'wget -O chainspec.json https://raw.githubusercontent.com/Cardinal-Cryptography/aleph-node/main/bin/node/src/resources/testnet_chainspec.json'
+        cmd = f'wget -O chainspec.json https://github.com/Cardinal-Cryptography/aleph-node/raw/main/bin/node/src/resources/testnet_chainspec.json'
         print(run(cmd.split(), capture_output=True))
         bootstrap_nodes(parties, chain, **chain_flags)
     generate_p2p_keys(parties)
@@ -554,7 +554,7 @@ def send_flooder_to_nodes(flooder_binary, regions=use_regions(), tag='dev'):
 
 def setup_nodes(n_parties, chain='dev', regions=use_regions(), instance_type='t2.micro', volume_size=8, tag='dev',
                 node_flags=None, benchmark_config=None, chain_flags=None, terminate_in_min=None, n_validators=None,
-                bootnodes=testnet_bootnodes(), sync_from_genesis=False):
+                bootnodes=testnet_bootnodes()):
     '''Setups the infrastructure and the binary. After it is successful, the 'dispatch'
     task has to be run to start the nodes.'''
 
@@ -572,7 +572,6 @@ def setup_nodes(n_parties, chain='dev', regions=use_regions(), instance_type='t2
     save_node_flags(node_flags or dict())
     if chain == 'testnet':
         write_bootnodes(bootnodes)
-        write_sync(sync_from_genesis)
         run_task('create-testnet-dispatch-cmd', regions, parallel, tag, pids)
     else:
         run_task('create-dispatch-cmd', regions, parallel, tag, pids)
@@ -631,12 +630,12 @@ def prepare_benchmark_script(benchmark_config, n_parties, regions=use_regions(),
 
 def setup_benchmark(n_parties, chain='dev', regions=use_regions(), instance_type='t2.micro', volume_size=8, tag='dev',
                     node_flags=None, benchmark_config=None, chain_flags=None, terminate_in_min=60, n_validators=None,
-                    bootnodes=testnet_bootnodes(), sync_from_genesis=False):
+                    bootnodes=testnet_bootnodes()):
     '''Setups the infrastructure and the binary. After it is successful, the 'dispatch'
     task has to be run to start the benchmark.'''
 
     pids = setup_nodes(n_parties, chain, regions, instance_type,
-                       volume_size, tag, node_flags, benchmark_config, chain_flags, terminate_in_min, n_validators, bootnodes, sync_from_genesis)
+                       volume_size, tag, node_flags, benchmark_config, chain_flags, terminate_in_min, n_validators, bootnodes)
 
     allow_all_traffic(regions, tag)
 

--- a/shell.py
+++ b/shell.py
@@ -507,9 +507,16 @@ def setup_infrastructure(n_parties, chain='dev', regions=use_regions(), instance
     os.makedirs('data', exist_ok=True)
 
     parties = generate_accounts(n_parties, chain, 'validator_phrases', 'validator_accounts')
-    bootstrap_chain(parties[:n_validators], chain,
-                    benchmark_config=benchmark_config, rich_accounts=parties[n_validators:], **chain_flags)
-    bootstrap_nodes(parties[n_validators:], chain, **chain_flags)
+    if chain != 'testnet':
+        color_print('Generating chainspec')
+        bootstrap_chain(parties[:n_validators], chain,
+                        benchmark_config=benchmark_config, rich_accounts=parties[n_validators:], **chain_flags)
+        bootstrap_nodes(parties[n_validators:], chain, **chain_flags)
+    else:
+        color_print('Downloading testnet chainspec')
+        cmd = f'wget -O chainspec.json https://raw.githubusercontent.com/Cardinal-Cryptography/aleph-node/main/bin/node/src/resources/testnet_chainspec.json'
+        print(run(cmd.split(), capture_output=True))
+        bootstrap_nodes(parties, chain, **chain_flags)
     generate_p2p_keys(parties)
 
     color_print('waiting till ports are open on machines')
@@ -546,7 +553,8 @@ def send_flooder_to_nodes(flooder_binary, regions=use_regions(), tag='dev'):
 
 
 def setup_nodes(n_parties, chain='dev', regions=use_regions(), instance_type='t2.micro', volume_size=8, tag='dev',
-                node_flags=None, benchmark_config=None, chain_flags=None, terminate_in_min=None, n_validators=None):
+                node_flags=None, benchmark_config=None, chain_flags=None, terminate_in_min=None, n_validators=None,
+                bootnodes=testnet_bootnodes(), sync_from_genesis=False):
     '''Setups the infrastructure and the binary. After it is successful, the 'dispatch'
     task has to be run to start the nodes.'''
 
@@ -562,7 +570,13 @@ def setup_nodes(n_parties, chain='dev', regions=use_regions(), instance_type='t2
     run_task('send-cli-binary', regions, parallel, tag)
 
     save_node_flags(node_flags or dict())
-    run_task('create-dispatch-cmd', regions, parallel, tag, pids)
+    if chain == 'testnet':
+        write_bootnodes(bootnodes)
+        write_sync(sync_from_genesis)
+        run_task('create-testnet-dispatch-cmd', regions, parallel, tag, pids)
+    else:
+        run_task('create-dispatch-cmd', regions, parallel, tag, pids)
+        
 
     run_task('install-prometheus-exporter', regions, parallel, tag)
 
@@ -616,12 +630,13 @@ def prepare_benchmark_script(benchmark_config, n_parties, regions=use_regions(),
 
 
 def setup_benchmark(n_parties, chain='dev', regions=use_regions(), instance_type='t2.micro', volume_size=8, tag='dev',
-                    node_flags=None, benchmark_config=None, chain_flags=None, terminate_in_min=60):
+                    node_flags=None, benchmark_config=None, chain_flags=None, terminate_in_min=60, n_validators=None,
+                    bootnodes=testnet_bootnodes(), sync_from_genesis=False):
     '''Setups the infrastructure and the binary. After it is successful, the 'dispatch'
     task has to be run to start the benchmark.'''
 
     pids = setup_nodes(n_parties, chain, regions, instance_type,
-                       volume_size, tag, node_flags, benchmark_config, chain_flags, terminate_in_min)
+                       volume_size, tag, node_flags, benchmark_config, chain_flags, terminate_in_min, n_validators, bootnodes, sync_from_genesis)
 
     allow_all_traffic(regions, tag)
 

--- a/utils.py
+++ b/utils.py
@@ -317,8 +317,8 @@ def bootstrap_nodes(account_ids, chain, **custom_flags):
         cmd += ['--chain-id', 'a0dnet1', '--n-members', f'{len(account_ids)}']
     else:
         flags = {
-            '--chain-id': 'a0tnet1',
-            '--chain-name': 'AlephZeroTestnet',
+            '--chain-id': 'testnet',
+            '--chain-name': 'Aleph Zero Testnet',
             '--token-symbol': 'TZERO',
         }
         flags.update(custom_flags)
@@ -427,10 +427,29 @@ def write_addresses(ip_list):
         for ip in ip_list:
             f.write(ip+'\n')
 
+def write_sync(sync_from_genesis):
+    with open('sync_from_genesis', 'w') as f:
+        if sync_from_genesis:
+            f.write('True\n')
+        else:
+            f.write('False\n')
+
+def write_bootnodes(bootnodes):
+    with open('bootnodes', 'w') as f:
+        for bootnode in bootnodes:
+            f.write(bootnode+'\n')
 
 def use_regions():
     return ['eu-central-1', 'eu-west-1', 'eu-west-2', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
 
+def testnet_bootnodes():
+    return [
+        '/dns4/bootnode-eu-central-1-0.test.azero.dev/tcp/30333/p2p/12D3KooWRkGLz4YbVmrsWK75VjFTs8NvaBu42xhAmQaP4KeJpw1L',
+        '/dns4/bootnode-eu-west-1-0.test.azero.dev/tcp/30333/p2p/12D3KooWFVXnvJdPuGnGYMPn5qLQAQYwmRBgo6SmEQsKZSrDoo2k',
+        '/dns4/bootnode-eu-west-2-0.test.azero.dev/tcp/30333/p2p/12D3KooWAkqYFFKMEJn6fnPjYnbuBBsBZq6fRFJZYR6rxnuCZWCC',
+        '/dns4/bootnode-us-east-1-0.test.azero.dev/tcp/30333/p2p/12D3KooWQFkkFr5aM5anGEiUCQiGUdRyWgrdpvSjBgWAUS9srLE4',
+        '/dns4/bootnode-us-east-2-0.test.azero.dev/tcp/30333/p2p/12D3KooWD5s2dkifJua69RbLwEREDdJjsNHvavNRGxdCvzhoeaLc'
+    ]
 
 def default_region():
     ''' Helper function for getting default region name for current setup.'''

--- a/utils.py
+++ b/utils.py
@@ -427,13 +427,6 @@ def write_addresses(ip_list):
         for ip in ip_list:
             f.write(ip+'\n')
 
-def write_sync(sync_from_genesis):
-    with open('sync_from_genesis', 'w') as f:
-        if sync_from_genesis:
-            f.write('True\n')
-        else:
-            f.write('False\n')
-
 def write_bootnodes(bootnodes):
     with open('bootnodes', 'w') as f:
         for bootnode in bootnodes:


### PR DESCRIPTION
This PR is part of work on connecting 100 nodes to testnet. It introduces option to connect to testnet using our Aleph-Testnet repo. Way it is done is just passing `chain='testnet'` to either `setup_nodes` or `setup_benchmark`. The script depending on 
* bootnodes argument will pass hardcoded bootnodes for testnet or provided ones
* sync_from_genesis will sync from block 0 or download testnet db